### PR TITLE
Use `http://` for jetbus link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # next-todos
-About 200 lines isomorphic todos app powered by [next.js](https://github.com/zeit/next.js/), [redux](https://github.com/reactjs/redux) and [Jet](https://jetbus.io) realtime. 
+About 200 lines isomorphic todos app powered by [next.js](https://github.com/zeit/next.js/), [redux](https://github.com/reactjs/redux) and [Jet](http://jetbus.io) realtime. 
 
 The todos are synced between browsers.
 


### PR DESCRIPTION
Chrome complains when you link to an insecure page (implementing only http) with an `https` link.

![screenshot 2016-12-05 11 20 00](https://cloud.githubusercontent.com/assets/635300/20898876/e89b09e8-badc-11e6-9e46-7a6d0dee9916.png)
